### PR TITLE
Add `attach` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,7 @@ services:                         # definition of services
       cql:                        # Requires a cassandra container to be linked
         - schema.cql              # Array of cql files that will be executed
         - default-data.cql        # against the linked cassandra
+    attach: True                  # Run container with an open tty, you can jump into it by running `docker attach`
   - name: cronjob
     repo: some-repo/cronjob
     schedule:                     # you can run containers periodically with schedule

--- a/launcher/ansible/templates/service.yml
+++ b/launcher/ansible/templates/service.yml
@@ -42,6 +42,11 @@
           - {{ link }}:{{ link }}
           {% endfor -%}
         {% endif -%}
+
+        {% if service.get('attach') %}
+        detach: False
+        stdin_open: True
+        {% endif -%}
     {% else %}
     {% for schedule in service.get('schedule') %}
     - name: Create {{ service.get('name') }} service

--- a/launcher/util/schema/stack_conf.yml
+++ b/launcher/util/schema/stack_conf.yml
@@ -58,6 +58,8 @@ required:
               onboot: //str
               schedule: //str
               description: //str
+        attach:
+          type: //bool
 optional:
   version: //num
   logging: //bool

--- a/tests/test_attach.py
+++ b/tests/test_attach.py
@@ -19,9 +19,22 @@
 # Docker Launcher. If not, see <http://www.gnu.org/licenses/>.
 #
 
-"""Module for transforming and launching stack configs"""
-import os
 
-VERSION = "0.1.2"
-CONFIGURATION = os.getenv('XDG_CONFIG_HOME',
-                          os.environ['HOME'] + '/.config') + '/docker-launcher'
+from launcher.util.stack_config import StackConf
+import pytest
+
+
+@pytest.fixture(scope="function")
+def valid_service():
+    return {
+        'services': [{
+            'name': 'test_service',
+            'repo': 'test/repo',
+            'attach': True
+        }]
+    }
+
+
+def test_attach_is_valid(valid_service):
+    StackConf(valid_service)
+


### PR DESCRIPTION
Add the possibility to run a docker container with an attached tty. This
is required for example for running erlang applications, with an open
erlang shell. With docker attach you can attach to this shell.