### PR TITLE
Pin docker-py version as a workaround

### DIFF
--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -22,6 +22,6 @@
 """Module for transforming and launching stack configs"""
 import os
 
-VERSION = "0.1.3"
+VERSION = "0.1.4"
 CONFIGURATION = os.getenv('XDG_CONFIG_HOME',
                           os.environ['HOME'] + '/.config') + '/docker-launcher'

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ setup(name='docker-launcher',
       packages=find_packages(),
       include_package_data=True,
 
-      install_requires=['pyyaml', 'jinja2', 'boto', 'pyrx-ats', 'ansible', 'docker-py'],
+      install_requires=['pyyaml', 'jinja2', 'boto', 'pyrx-ats', 'ansible', 'docker-py==1.2.3'],
       extras_require={'dev': ['pytest', 'pytest-cov', 'pylint']},
 
       scripts=['bin/docker-launcher'])


### PR DESCRIPTION
This is necessary, because docker-py, docker and ansible don't play
nicely together, we need to find a way to make this dependent on the
docker version installed.