### PR TITLE
Fix string conversion in restart_policy

### DIFF
--- a/launcher/__init__.py
+++ b/launcher/__init__.py
@@ -22,6 +22,6 @@
 """Module for transforming and launching stack configs"""
 import os
 
-VERSION = "0.1.7"
+VERSION = "0.1.8"
 CONFIGURATION = os.getenv('XDG_CONFIG_HOME',
                           os.environ['HOME'] + '/.config') + '/docker-launcher'

--- a/launcher/ansible/templates/service.yml
+++ b/launcher/ansible/templates/service.yml
@@ -28,7 +28,7 @@
         state: reloaded
         {% endif -%}
         {% if service.get('restart_policy') != None -%}
-        restart_policy: {{service.get('restart_policy')}}
+        restart_policy: "{{service.get('restart_policy')}}"
         {% else %}
         restart_policy: always
         {% endif -%}

--- a/launcher/ansible/templates/service.yml
+++ b/launcher/ansible/templates/service.yml
@@ -22,7 +22,11 @@
       docker:
         image: {{ service.get('repo') }}
         name: {{ service.get('name') }}
+        {% if service.get('state') != None -%}
+        state: {{service.get('state')}}
+        {% else %}
         state: reloaded
+        {% endif -%}
         {% if service.get('restart_policy') != None -%}
         restart_policy: {{service.get('restart_policy')}}
         {% else %}

--- a/launcher/util/schema/stack_conf.yml
+++ b/launcher/util/schema/stack_conf.yml
@@ -27,6 +27,7 @@ required:
           values: //str
         advertised_port: //int
         restart_policy: //str
+        state: //str
         ports:
           type: //arr
           contents:

--- a/tests/stack-confs/state.yml
+++ b/tests/stack-confs/state.yml
@@ -1,0 +1,20 @@
+---
+services:
+  - name: mysql-data
+    restart_policy: "on-failure"
+    state: present
+    repo: busybox
+    volumes:
+      - /var/lib/mysql
+    command: "true"
+
+  - name: mysql-test
+    repo: mysql
+    ports:
+      - 3306
+    env:
+      MYSQL_ROOT_PASSWORD: "super-secret"
+      MYSQL_USER: "test"
+      MYSQL_PASSWORD: "super-secret"
+    volumes_from:
+      - mysql-data

--- a/tests/stack-confs/state.yml
+++ b/tests/stack-confs/state.yml
@@ -1,7 +1,7 @@
 ---
 services:
   - name: mysql-data
-    restart_policy: "on-failure"
+    restart_policy: "no"
     state: present
     repo: busybox
     volumes:

--- a/tests/target-playbooks/restart_policy.yml
+++ b/tests/target-playbooks/restart_policy.yml
@@ -9,7 +9,7 @@
         image: someone/one
         name: one
         state: reloaded
-        restart_policy: no
+        restart_policy: "no"
 
 - name: Deploy two
   hosts: local

--- a/tests/target-playbooks/state.yml
+++ b/tests/target-playbooks/state.yml
@@ -1,0 +1,31 @@
+- name: Deploy mysql-data
+  hosts: local
+  tags: mysql-data
+  tasks:
+    - name: Pull the mysql-data image
+      raw: docker pull busybox
+    - name: Launch mysql-data
+      docker:
+        image: busybox
+        name: mysql-data
+        state: present
+        restart_policy: on-failure
+        command: "true"
+        volumes: ['/var/lib/mysql']
+    
+- name: Deploy mysql-test
+  hosts: local
+  tags: mysql-test
+  tasks:
+    - name: Pull the mysql-test image
+      raw: docker pull mysql
+    - name: Launch mysql-test
+      docker:
+        image: mysql
+        name: mysql-test
+        state: reloaded
+        restart_policy: always
+        ports: ['3306:3306']
+        expose: ['3306']
+        volumes_from: ['mysql-data']
+        env: {'MYSQL_ROOT_PASSWORD': 'super-secret', 'MYSQL_PASSWORD': 'super-secret', 'MYSQL_USER': 'test'}

--- a/tests/target-playbooks/state.yml
+++ b/tests/target-playbooks/state.yml
@@ -9,7 +9,7 @@
         image: busybox
         name: mysql-data
         state: present
-        restart_policy: on-failure
+        restart_policy: "no"
         command: "true"
         volumes: ['/var/lib/mysql']
     

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -19,9 +19,13 @@
 # Docker Launcher. If not, see <http://www.gnu.org/licenses/>.
 #
 
-"""Module for transforming and launching stack configs"""
-import os
 
-VERSION = "0.1.7"
-CONFIGURATION = os.getenv('XDG_CONFIG_HOME',
-                          os.environ['HOME'] + '/.config') + '/docker-launcher'
+from test_library import run_playbook_test, run_schema_error_test
+from launcher.util.stack_config import StackConf
+from launcher.util.dict_wrapper import SchemaError
+import pytest
+
+def test_minimal_stack_conf():
+    """Test that the minimal stack conf is valid"""
+    run_playbook_test("tests/stack-confs/state.yml",
+                      "tests/target-playbooks/state.yml")


### PR DESCRIPTION
The value for `restart_policy` got converted to bool when passing no in
some cases. This happens on the ansible side, so after the first round
of templating, which means wrapping `no` in quotes didn't fix it.

With this fix correct quoting is enforced.